### PR TITLE
index: include latestnews.php in all translations

### DIFF
--- a/pages/de/index.php
+++ b/pages/de/index.php
@@ -115,13 +115,11 @@ $(document).ready(function() {
     <p>
       Release Notes werden im <a href="https://emu.freenetproject.org/pipermail/devl/">devl Archiv</a> veröffentlicht.
     </p>
-	<p>
-		  (12th July 2014) <a href="news.html#build01464">Freenet 0.7.5 build 1464 released</a><br/>
-		  (14th June 2014) <a href="news.html#build01463">Freenet 0.7.5 build 1463 released</a><br/>
-		  (26th May 2014) <a href="news.html#build01462">Freenet 0.7.5 build 1462 released</a><br/>
-		  (30th March 2014) <a href="news.html#build01461">Freenet 0.7.5 build 1461 released</a><br/>
-		  (1st March 2014) <a href="news.html#gsoc-2014">Freenet accepted into Google Summer of Code!</a><br/>
-    </p>
+    <p>
+	<?php
+		include("pages/en/latestnews.php");
+	?>
+    </p>                                                             
     <p>
 	  <a href="news.html">Ältere Neuigkeiten</a>
 	</p>

--- a/pages/en/index.php
+++ b/pages/en/index.php
@@ -120,14 +120,10 @@ $(document).ready(function() {
 	<h4>Latest news</h4>
 
 	<p>
-		  (2015-03-29) <a href="news.html#20150329-new-installer">New Linux/Unix/OS X installer</a></br>
-		  (2015-03-15) <a href="news.html#20150315-1468-progress">Progress toward build 1468</a></br>
-		  (2015-03-14) <a href="news.html#20150314-localization-lab">Freenet translation joins Localization Lab</a></br>
-		  (2015-02-15) <a href="news.html#20150215-csharp-tray">New Windows tray app for testing</a></br>
-	          (2015-02-11) <a href="news.html#20150211-suma-award">Freenet received the SUMA Award 2015</a><br/>
-	          (2015-01-05) <a href="news.html#20150105-mempo-apt-get">apt-get over Freenet</a><br/>
-		  (2014-11-23) <a href="news.html#build01467">Freenet 0.7.5 build 1467 released</a><br/>
-          </p>
+	<?php 
+		include("pages/en/latestnews.php");
+	?>
+    </p>
     <p>
 	  <a href="news.html">Older news</a>
 	</p>

--- a/pages/en/latestnews.php
+++ b/pages/en/latestnews.php
@@ -1,0 +1,7 @@
+		  (2015-03-29) <a href="news.html#20150329-new-installer">New Linux/Unix/OS X installer</a></br>
+		  (2015-03-15) <a href="news.html#20150315-1468-progress">Progress toward build 1468</a></br>
+		  (2015-03-14) <a href="news.html#20150314-localization-lab">Freenet translation joins Localization Lab</a></br>
+		  (2015-02-15) <a href="news.html#20150215-csharp-tray">New Windows tray app for testing</a></br>
+          (2015-02-11) <a href="news.html#20150211-suma-award">Freenet received the SUMA Award 2015</a><br/>
+          (2015-01-05) <a href="news.html#20150105-mempo-apt-get">apt-get over Freenet</a><br/>
+		  (2014-11-23) <a href="news.html#build01467">Freenet 0.7.5 build 1467 released</a><br/>

--- a/pages/es/index.php
+++ b/pages/es/index.php
@@ -108,8 +108,12 @@ $(document).ready(function() {
 
       <div id="news">
 	<h4>Ultimas noticias</h4>
+    <p>
+	<?php
+		include("pages/en/latestnews.php");
+	?>
+    </p>
 	<p>
-	  (13 de Abril 2011) <a href="news.html#freedom-house-april-2011">¡Freenet máxima herramienta anticensura en encuesta a usuarios Chinos!</a><br/>
 	  <a href="news.html">Noticias anteriores</a>
 	</p>
       </div>

--- a/pages/fr/index.php
+++ b/pages/fr/index.php
@@ -105,11 +105,12 @@ $(document).ready(function() {
 
       <div id="news">
 	<h4>Dernières nouvelles (en anglais pour l'instant)</h4>
+    <p>
+	<?php
+		include("pages/en/latestnews.php");
+	?>
+    </p>
 	<p> 
-          (26th March 2012) <a href="https://twitter.com/#!/nextgens1/status/184713742448201728">If you are a student and you fancy flipping bits rather than burgers, you should consider applying for Google Summer of Code 2012! Registration is now open: send us your proposals!</a><br />
-          (16th March 2012) <a href="https://www.google-melange.com/gsoc/org/google/gsoc2012/freenet">Freenet has been accepted as a mentoring organization for Google Summer of Code 2012!</a><br />
-          (15th November 2011) <a href="https://emu.freenetproject.org/pipermail/devl/2011-November/035824.html">Released Freenet 0.7.5 build 1405</a><br />
-          (13th April 2011) <a href="news.html#freedom-house-april-2011">Freenet top anti-censorship tool in survey of Chinese users!</a><br/>
 	  <a href="news.html">Older news</a>
 	</p>
       </div>

--- a/pages/ru/index.php
+++ b/pages/ru/index.php
@@ -108,6 +108,12 @@ $(document).ready(function() {
 
       <div id="news">
   <h4>Последние новости</h4>
+    <p>
+	<?php
+		include("pages/en/latestnews.php");
+	?>
+    </p>
+
   <p>
         (26 июня 2013) <a href="news.html#2013-second-developer-xor">Фринет нанимает второго разработчика!</a><br/>
         (8 апреля 2013) <a href="news.html#2013-summer-of-code-accepted">Фринет принят на Google Summer of Code 2013!</a><br/>

--- a/pages/zh-cn/index.php
+++ b/pages/zh-cn/index.php
@@ -108,6 +108,12 @@ $(document).ready(function() {
 
       <div id="news">
 	<h4>最新新闻</h4>
+    <p>
+	<?php
+		include("pages/en/latestnews.php");
+	?>
+    </p>
+
 	<p>
           (2012 年 4 月 14 日) <a href="https://emu.freenetproject.org/pipermail/devl/2012-April/036354.html">发布 Freenet 0.7.5 build 1407</a><br />
           (2012 年 4 月 3 日) <a href="https://emu.freenetproject.org/pipermail/devl/2012-April/036295.html">发布 Freenet 0.7.5 build 1406</a><br />


### PR DESCRIPTION
This resolves the stale news on translated pages.

Translated news can be added on the index page in addition to the included news.
